### PR TITLE
Add ability to show a banner

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -13,6 +13,7 @@
   from-address: none,
   to-name: none,
   to-address: none,
+  banner: none,
   date: none,
   salutation: none,
   subject: none,
@@ -117,6 +118,8 @@
     set text(font: footnote-font, size: footnote-font-size)
     it
   }
+
+  banner;
 
   // Sender's name, address, and date block
   align(from-alignment, block[

--- a/template/main.typ
+++ b/template/main.typ
@@ -16,6 +16,12 @@
   // attn-address: "Attn:",
   // attn-position: "above",
 
+  // Banner at the top of the letter
+  // banner: image(
+  //   "path/to/my-banner.svg",
+  //    width: 100%
+  // ),
+
   // Letter date (automatically set to today's date)
   date: datetime.today().display("[day padding:zero] [month repr:long] [year repr:full]"),
 


### PR DESCRIPTION
Thanks for this lovely letter template! I'm wrapping it for the myst documentation engine :heart:

This PR adds a letter banner, which is useful for showing, e.g., your institutional affiliation graphically.

Example letter generated this way: https://github.com/stefanv/myst-typst-letterloom/blob/example/letter.pdf

Not sure if you want some verification done on that field; since it is free-form, I am not sure what to check for.